### PR TITLE
Initial ZFS commit

### DIFF
--- a/lib/modules/configure.go
+++ b/lib/modules/configure.go
@@ -136,11 +136,11 @@ func getBlockConfigInstance(m map[string]interface{}) (*BlockConfig, error) {
 		err := yaml.Unmarshal(yamlStr, &c)
 		b := BlockConfig(c)
 		return &b, err
-  case "zfs":
-    c := Zfs{}
-    err := yaml.Unmarshal(yamlStr, &c)
-    b := BlockConfig(c)
-    return &b, err
+	case "zfs":
+		c := Zfs{}
+		err := yaml.Unmarshal(yamlStr, &c)
+		b := BlockConfig(c)
+		return &b, err
 	}
 	return nil, fmt.Errorf("error: type %s not valid", t)
 }

--- a/lib/modules/configure.go
+++ b/lib/modules/configure.go
@@ -136,6 +136,11 @@ func getBlockConfigInstance(m map[string]interface{}) (*BlockConfig, error) {
 		err := yaml.Unmarshal(yamlStr, &c)
 		b := BlockConfig(c)
 		return &b, err
+  case "zfs":
+    c := Zfs{}
+    err := yaml.Unmarshal(yamlStr, &c)
+    b := BlockConfig(c)
+    return &b, err
 	}
 	return nil, fmt.Errorf("error: type %s not valid", t)
 }

--- a/lib/modules/zfs.go
+++ b/lib/modules/zfs.go
@@ -1,7 +1,6 @@
 package modules
 
 import (
-	"bufio"
 	"fmt"
 	"github.com/davidscholberg/go-i3barjson"
 	"os/exec"
@@ -20,7 +19,7 @@ func (c Zfs) UpdateBlock(b *i3barjson.Block) {
 	fullTextFmt := fmt.Sprintf("%s%%s", c.Label)
 
 	zpoolCmd := exec.Command("sudo", "zpool", "status", c.PoolName)
-	out, err := zpoolCmd.StdoutPipe()
+	out, err := zpoolCmd.Output()
 
 	if err != nil {
 		b.Urgent = true
@@ -28,17 +27,9 @@ func (c Zfs) UpdateBlock(b *i3barjson.Block) {
 		return
 	}
 
-	if err := zpoolCmd.Start(); err != nil {
-		b.Urgent = true
-		b.FullText = fmt.Sprintf(fullTextFmt, err.Error())
-		return
-	}
-
-	defer zpoolCmd.Wait()
-
-	buff := bufio.NewScanner(out)
-	for buff.Scan() {
-		line := strings.TrimSpace(buff.Text())
+	zpoolLines := strings.Split(string(out), "\n")
+	for _, zpoolLine := range zpoolLines {
+		line := strings.TrimSpace(zpoolLine)
 		if strings.HasPrefix(line, "state") {
 			split := strings.Split(line, ":")
 			status := strings.TrimSpace(split[1])

--- a/lib/modules/zfs.go
+++ b/lib/modules/zfs.go
@@ -18,7 +18,7 @@ type Zfs struct {
 // UpdateBlock updates the ZFS block
 func (c Zfs) UpdateBlock(b *i3barjson.Block) {
 	b.Color = c.Color
-	fullTextFmt := fmt.Sprintf("%s%s - %%s", c.Label, c.PoolName)
+	fullTextFmt := fmt.Sprintf("%s%%s", c.Label)
 
 	zpoolCmd := exec.Command("sudo", c.ZpoolBin, "status", c.PoolName)
 	out, err := zpoolCmd.StdoutPipe()

--- a/lib/modules/zfs.go
+++ b/lib/modules/zfs.go
@@ -1,0 +1,59 @@
+package modules
+
+import (
+  "github.com/davidscholberg/go-i3barjson"
+  "fmt"
+  "os/exec"
+  "bufio"
+  "strings"
+)
+
+type Zfs struct {
+  BlockConfigBase `yaml:",inline"`
+  PoolName        string `yaml:"zpool_name"`
+}
+
+func (c Zfs) UpdateBlock(b *i3barjson.Block) {
+  b.Color = c.Color
+  fullTextFmt := fmt.Sprintf("%s%s - %%s", c.Label, c.PoolName)
+
+  zpoolCmd := exec.Command("sudo","/sbin/zpool","status", c.PoolName)
+  out,err := zpoolCmd.StdoutPipe()
+
+  if err != nil {
+    b.Urgent = true
+    b.FullText = fmt.Sprintf(fullTextFmt,err.Error())
+    return
+  }
+
+  if err := zpoolCmd.Start(); err != nil {
+    b.Urgent = true
+    b.FullText = fmt.Sprintf(fullTextFmt,err.Error())
+    return
+  }
+
+  defer zpoolCmd.Wait()
+
+  buff := bufio.NewScanner(out)
+  for buff.Scan() {
+    line := strings.TrimSpace(buff.Text())
+    if strings.HasPrefix(line,"state") {
+      split := strings.Split(line,":")
+      status := strings.TrimSpace(split[1])
+
+      if status == "ONLINE" {
+        b.Urgent = false
+      } else {
+        b.Urgent = true
+      }
+      b.FullText = fmt.Sprintf(fullTextFmt,status)
+      return 
+    }
+  }
+
+  b.Urgent = true
+  b.FullText = fmt.Sprintf(fullTextFmt,"NOT FOUND")
+  return
+}
+
+

--- a/lib/modules/zfs.go
+++ b/lib/modules/zfs.go
@@ -12,7 +12,6 @@ import (
 type Zfs struct {
 	BlockConfigBase `yaml:",inline"`
 	PoolName        string `yaml:"zpool_name"`
-	ZpoolBin        string `yaml:"zpool_bin"`
 }
 
 // UpdateBlock updates the ZFS block
@@ -20,7 +19,7 @@ func (c Zfs) UpdateBlock(b *i3barjson.Block) {
 	b.Color = c.Color
 	fullTextFmt := fmt.Sprintf("%s%%s", c.Label)
 
-	zpoolCmd := exec.Command("sudo", c.ZpoolBin, "status", c.PoolName)
+	zpoolCmd := exec.Command("sudo", "zpool", "status", c.PoolName)
 	out, err := zpoolCmd.StdoutPipe()
 
 	if err != nil {

--- a/lib/modules/zfs.go
+++ b/lib/modules/zfs.go
@@ -1,60 +1,60 @@
 package modules
 
 import (
-  "github.com/davidscholberg/go-i3barjson"
-  "fmt"
-  "os/exec"
-  "bufio"
-  "strings"
+	"bufio"
+	"fmt"
+	"github.com/davidscholberg/go-i3barjson"
+	"os/exec"
+	"strings"
 )
 
+// Zfs represents the configuration data for the ZFS block
 type Zfs struct {
-  BlockConfigBase `yaml:",inline"`
-  PoolName        string `yaml:"zpool_name"`
-  ZpoolBin        string `yaml:"zpool_bin"`
+	BlockConfigBase `yaml:",inline"`
+	PoolName        string `yaml:"zpool_name"`
+	ZpoolBin        string `yaml:"zpool_bin"`
 }
 
+// UpdateBlock updates the ZFS block
 func (c Zfs) UpdateBlock(b *i3barjson.Block) {
-  b.Color = c.Color
-  fullTextFmt := fmt.Sprintf("%s%s - %%s", c.Label, c.PoolName)
+	b.Color = c.Color
+	fullTextFmt := fmt.Sprintf("%s%s - %%s", c.Label, c.PoolName)
 
-  zpoolCmd := exec.Command("sudo", c.ZpoolBin, "status", c.PoolName)
-  out,err := zpoolCmd.StdoutPipe()
+	zpoolCmd := exec.Command("sudo", c.ZpoolBin, "status", c.PoolName)
+	out, err := zpoolCmd.StdoutPipe()
 
-  if err != nil {
-    b.Urgent = true
-    b.FullText = fmt.Sprintf(fullTextFmt,err.Error())
-    return
-  }
+	if err != nil {
+		b.Urgent = true
+		b.FullText = fmt.Sprintf(fullTextFmt, err.Error())
+		return
+	}
 
-  if err := zpoolCmd.Start(); err != nil {
-    b.Urgent = true
-    b.FullText = fmt.Sprintf(fullTextFmt,err.Error())
-    return
-  }
+	if err := zpoolCmd.Start(); err != nil {
+		b.Urgent = true
+		b.FullText = fmt.Sprintf(fullTextFmt, err.Error())
+		return
+	}
 
-  defer zpoolCmd.Wait()
+	defer zpoolCmd.Wait()
 
-  buff := bufio.NewScanner(out)
-  for buff.Scan() {
-    line := strings.TrimSpace(buff.Text())
-    if strings.HasPrefix(line,"state") {
-      split := strings.Split(line,":")
-      status := strings.TrimSpace(split[1])
+	buff := bufio.NewScanner(out)
+	for buff.Scan() {
+		line := strings.TrimSpace(buff.Text())
+		if strings.HasPrefix(line, "state") {
+			split := strings.Split(line, ":")
+			status := strings.TrimSpace(split[1])
 
-      if status == "ONLINE" {
-        b.Urgent = false
-      } else {
-        b.Urgent = true
-      }
-      b.FullText = fmt.Sprintf(fullTextFmt,status)
-      return 
-    }
-  }
+			if status == "ONLINE" {
+				b.Urgent = false
+			} else {
+				b.Urgent = true
+			}
+			b.FullText = fmt.Sprintf(fullTextFmt, status)
+			return
+		}
+	}
 
-  b.Urgent = true
-  b.FullText = fmt.Sprintf(fullTextFmt,"NOT FOUND")
-  return
+	b.Urgent = true
+	b.FullText = fmt.Sprintf(fullTextFmt, "NOT FOUND")
+	return
 }
-
-

--- a/lib/modules/zfs.go
+++ b/lib/modules/zfs.go
@@ -11,13 +11,14 @@ import (
 type Zfs struct {
   BlockConfigBase `yaml:",inline"`
   PoolName        string `yaml:"zpool_name"`
+  ZpoolBin        string `yaml:"zpool_bin"`
 }
 
 func (c Zfs) UpdateBlock(b *i3barjson.Block) {
   b.Color = c.Color
   fullTextFmt := fmt.Sprintf("%s%s - %%s", c.Label, c.PoolName)
 
-  zpoolCmd := exec.Command("sudo","/sbin/zpool","status", c.PoolName)
+  zpoolCmd := exec.Command("sudo", c.ZpoolBin, "status", c.PoolName)
   out,err := zpoolCmd.StdoutPipe()
 
   if err != nil {


### PR DESCRIPTION
Output of 'zpool status **pool**'

```
$ sudo zpool status boot
  pool: boot
 state: ONLINE
  scan: scrub repaired 0 in 0h9m with 0 errors on Fri Oct 14 16:21:56 2016
config:

    NAME        STATE     READ WRITE CKSUM
    boot        ONLINE       0     0     0
      mirror-0  ONLINE       0     0     0
        sda1    ONLINE       0     0     0
        sdb1    ONLINE       0     0     0

errors: No known data errors
```

Sample config entry:

``` yaml
blocks:
  - type: zfs
    label: "ZFS: "
    zpool_name: "boot"
    color: "#00ff00"
    update_interval: 60
```

Sample sudoers entry:
`ALL ALL = (root) NOPASSWD: /sbin/zpool status *`

I've added a new block called 'zfs' that accepts 'zpool_name',  and 'label' as configuration arguments utilized in the block output.  'zpool' needs to be in the users PATH. First go code I've ever written, please let me know if there are stylistic or syntax/logic changes you'd like done.
