### PR TITLE
more iface details

### DIFF
--- a/lib/modules/iface.go
+++ b/lib/modules/iface.go
@@ -3,38 +3,62 @@ package modules
 import (
 	"fmt"
 	"github.com/davidscholberg/go-i3barjson"
-	"os"
+	"net"
+	"strings"
 )
 
 // Interface represents the configuration for the network interface block.
 type Interface struct {
 	BlockConfigBase `yaml:",inline"`
 	IfaceName       string `yaml:"interface_name"`
+	IPv4            string
+	IPv4CIDR        string
+	IPv6            string
+	IPv6CIDR        string
 }
 
 // UpdateBlock updates the network interface block.
 func (c Interface) UpdateBlock(b *i3barjson.Block) {
 	b.Color = c.Color
 	fullTextFmt := fmt.Sprintf("%s%%s", c.Label)
-	var statusStr string
-	sysFilePath := fmt.Sprintf("/sys/class/net/%s/operstate", c.IfaceName)
-	r, err := os.Open(sysFilePath)
+
+	iface, err := net.InterfaceByName(c.IfaceName)
 	if err != nil {
 		b.Urgent = true
 		b.FullText = fmt.Sprintf(fullTextFmt, err.Error())
 		return
 	}
-	defer r.Close()
-	_, err = fmt.Fscanf(r, "%s", &statusStr)
-	if err != nil {
-		b.Urgent = true
-		b.FullText = fmt.Sprintf(fullTextFmt, err.Error())
-		return
-	}
-	if statusStr == "up" {
+
+	if iface.Flags == net.FlagUp {
 		b.Urgent = false
 	} else {
 		b.Urgent = true
 	}
-	b.FullText = fmt.Sprintf(fullTextFmt, statusStr)
+
+	addrs, err := iface.Addrs()
+	if err != nil {
+		b.Urgent = true
+		b.FullText = fmt.Sprintf(fullTextFmt, err.Error())
+		return
+	}
+
+	for _, addr := range addrs {
+		ip, _, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			b.Urgent = true
+			b.FullText = fmt.Sprintf(fullTextFmt, err.Error())
+			return
+		}
+
+		// Checking for address family
+		if ip.To4() != nil {
+			c.Label = strings.Replace(c.Label, "\u003cipv4\u003e", ip.String(), -1)
+			c.Label = strings.Replace(c.Label, "\u003ccidr4\u003e", addr.String(), -1)
+		} else {
+			c.Label = strings.Replace(c.Label, "\u003cipv6\u003e", ip.String(), -1)
+			c.Label = strings.Replace(c.Label, "\u003ccidr6\u003e", addr.String(), -1)
+		}
+	}
+
+	b.FullText = fmt.Sprintf(fullTextFmt, c.Label)
 }

--- a/lib/modules/iface.go
+++ b/lib/modules/iface.go
@@ -15,10 +15,15 @@ type Interface struct {
 	IPv4CIDR        string
 	IPv6            string
 	IPv6CIDR        string
+	IPv6Local       string
 }
 
 // UpdateBlock updates the network interface block.
 func (c Interface) UpdateBlock(b *i3barjson.Block) {
+	var (
+		status string
+	)
+
 	b.Color = c.Color
 	fullTextFmt := fmt.Sprintf("%s%%s", c.Label)
 
@@ -31,8 +36,10 @@ func (c Interface) UpdateBlock(b *i3barjson.Block) {
 
 	if iface.Flags == net.FlagUp {
 		b.Urgent = false
+		status = "up"
 	} else {
 		b.Urgent = true
+		status = "down"
 	}
 
 	addrs, err := iface.Addrs()
@@ -52,13 +59,30 @@ func (c Interface) UpdateBlock(b *i3barjson.Block) {
 
 		// Checking for address family
 		if ip.To4() != nil {
-			c.Label = strings.Replace(c.Label, "\u003cipv4\u003e", ip.String(), -1)
-			c.Label = strings.Replace(c.Label, "\u003ccidr4\u003e", addr.String(), -1)
+			fullTextFmt = strings.Replace(fullTextFmt, "\u003cipv4\u003e", ip.String(), -1)
+			fullTextFmt = strings.Replace(fullTextFmt, "\u003ccidr4\u003e", addr.String(), -1)
 		} else {
-			c.Label = strings.Replace(c.Label, "\u003cipv6\u003e", ip.String(), -1)
-			c.Label = strings.Replace(c.Label, "\u003ccidr6\u003e", addr.String(), -1)
+
+			if ip.String()[0:4] == "fe80" {
+				//setting ipv6 link local
+				fullTextFmt = strings.Replace(fullTextFmt, "\u003clocal6\u003e", ip.String(), -1)
+			} else {
+				fullTextFmt = strings.Replace(fullTextFmt, "\u003cipv6\u003e", ip.String()[0:3], -1)
+				fullTextFmt = strings.Replace(fullTextFmt, "\u003ccidr6\u003e", addr.String(), -1)
+			}
 		}
 	}
 
-	b.FullText = fmt.Sprintf(fullTextFmt, c.Label)
+	// setting up/down flag
+	fullTextFmt = strings.Replace(fullTextFmt, "\u003cstatus\u003e", status, -1)
+
+	// clearing unset fields i.e. because of ipv6 single-stack
+	fullTextFmt = strings.Replace(fullTextFmt, "\u003cipv4\u003e", "", -1)
+	fullTextFmt = strings.Replace(fullTextFmt, "\u003ccidr4\u003e", "", -1)
+	fullTextFmt = strings.Replace(fullTextFmt, "\u003cipv6\u003e", "", -1)
+	fullTextFmt = strings.Replace(fullTextFmt, "\u003ccidr6\u003e", "", -1)
+	fullTextFmt = strings.Replace(fullTextFmt, "\u003clocal6\u003e", "", -1)
+
+	// removing the last %s placeholder from final string
+	b.FullText = fmt.Sprintf(fullTextFmt, "")
 }

--- a/lib/modules/iface.go
+++ b/lib/modules/iface.go
@@ -15,7 +15,6 @@ type Interface struct {
 	IPv4CIDR        string
 	IPv6            string
 	IPv6CIDR        string
-	IPv6Local       string
 }
 
 // UpdateBlock updates the network interface block.
@@ -67,7 +66,7 @@ func (c Interface) UpdateBlock(b *i3barjson.Block) {
 				//setting ipv6 link local
 				fullTextFmt = strings.Replace(fullTextFmt, "\u003clocal6\u003e", ip.String(), -1)
 			} else {
-				fullTextFmt = strings.Replace(fullTextFmt, "\u003cipv6\u003e", ip.String()[0:3], -1)
+				fullTextFmt = strings.Replace(fullTextFmt, "\u003cipv6\u003e", ip.String(), -1)
 				fullTextFmt = strings.Replace(fullTextFmt, "\u003ccidr6\u003e", addr.String(), -1)
 			}
 		}


### PR DESCRIPTION
**What's different?**
- using net package
- output format with placeholders
- returns IPv4 and IPv6 address
- returns [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) of v4/v6 address


**Example config block**
```
 - type: interface
      label: "E: <ipv4> <ipv6> <cidr4> <cidr6>"
      interface_name: eth0
```

