### PR TITLE
Allow the amixer mixer name to be changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The main goal of this project is to have all of the status indicator modules wri
     * network interfaces (up/down status, IP addresses)
     * wifi signal strength
     * battery level
-    * volume (ALSA only)
+    * volume (ALSA or default Pulse sink)
     * uptime
     * date/time
 * Configuration in [YAML](http://yaml.org/) format (see [config/goblocks-full.yml](config/goblocks-full.yml)).

--- a/config/goblocks-full.yml
+++ b/config/goblocks-full.yml
@@ -128,12 +128,14 @@ blocks:
       battery_number: 0
       crit_battery: 20
 
-    # The volume block currently only supports the ALSA master channel volume.
+    # The volume block currently supports the Pulse or ALSA master channel volume.
     # The amixer utility must be installed and in your $PATH.
     - type: volume
       update_interval: 60
       label: "V: "
       update_signal: 1
+    # * mixer_type  - 'default' or 'pulse'
+      mixer_type: default 
 
     - type: uptime
       update_interval: 0.5

--- a/config/goblocks-full.yml
+++ b/config/goblocks-full.yml
@@ -134,8 +134,8 @@ blocks:
       update_interval: 60
       label: "V: "
       update_signal: 1
-    # * mixer_type  - 'default' or 'pulse'
-      mixer_type: default 
+    # * mixer_device  - 'default' or 'pulse'
+      mixer_device: default 
 
     - type: uptime
       update_interval: 0.5

--- a/config/goblocks-screenshot.yml
+++ b/config/goblocks-screenshot.yml
@@ -41,6 +41,7 @@ blocks:
       color: "#71b58e"
       update_interval: 60
       update_signal: 8
+      mixer_type: default
 
     - type: time
       update_interval: 0.5

--- a/config/goblocks-screenshot.yml
+++ b/config/goblocks-screenshot.yml
@@ -41,7 +41,7 @@ blocks:
       color: "#71b58e"
       update_interval: 60
       update_signal: 8
-      mixer_type: default
+      mixer_device: default
 
     - type: time
       update_interval: 0.5

--- a/lib/modules/volume.go
+++ b/lib/modules/volume.go
@@ -10,7 +10,7 @@ import (
 // Volume represents the configuration for the volume display block.
 type Volume struct {
 	BlockConfigBase `yaml:",inline"`
-	MixerType       string `yaml:"mixer_type"`
+	MixerDevice     string `yaml:"mixer_device"`
 }
 
 // UpdateBlock updates the volume display block.
@@ -19,7 +19,10 @@ func (c Volume) UpdateBlock(b *i3barjson.Block) {
 	b.Color = c.Color
 	fullTextFmt := fmt.Sprintf("%s%%s", c.Label)
 	amixerCmd := "amixer"
-	amixerArgs := []string{"-D", c.MixerType, "get", "Master"}
+	if c.MixerDevice == "" {
+		c.MixerDevice = "default"
+	}
+	amixerArgs := []string{"-D", c.MixerDevice, "get", "Master"}
 	out, err := exec.Command(amixerCmd, amixerArgs...).Output()
 	if err != nil {
 		b.FullText = fmt.Sprintf(fullTextFmt, err.Error())

--- a/lib/modules/volume.go
+++ b/lib/modules/volume.go
@@ -10,6 +10,7 @@ import (
 // Volume represents the configuration for the volume display block.
 type Volume struct {
 	BlockConfigBase `yaml:",inline"`
+	MixerType       string `yaml:"mixer_type"`
 }
 
 // UpdateBlock updates the volume display block.
@@ -18,7 +19,7 @@ func (c Volume) UpdateBlock(b *i3barjson.Block) {
 	b.Color = c.Color
 	fullTextFmt := fmt.Sprintf("%s%%s", c.Label)
 	amixerCmd := "amixer"
-	amixerArgs := []string{"-D", "default", "get", "Master"}
+	amixerArgs := []string{"-D", c.MixerType, "get", "Master"}
 	out, err := exec.Command(amixerCmd, amixerArgs...).Output()
 	if err != nil {
 		b.FullText = fmt.Sprintf(fullTextFmt, err.Error())


### PR DESCRIPTION
This allows amixer to report the PulseAudio default mixer volume. Both example configuration files have been updated to reflect the proposed change.