### PR TITLE
Added CPU usage block

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The main goal of this project is to have all of the status indicator modules wri
     * RAID status (mdraid only)
     * filesystem usage
     * system load
+    * CPU usage
     * memory availability
     * CPU temperature
     * network interfaces (up/down status, IP addresses)

--- a/config/goblocks-full.yml
+++ b/config/goblocks-full.yml
@@ -83,6 +83,14 @@ blocks:
       label: "L: "
       crit_load: 4
 
+    # The CPU usage in percents.
+    - type: cpu
+      label: "U: "
+      crit_usage: 0.8
+      # By default an aggregated value for all cores is displayed.
+      # Individual core on multi-core machine can be specified. See /proc/stat for possible values.
+      # cpu: cpu0
+
     # The memory block displays available memory.
     - type: memory
       label: "M: "

--- a/lib/modules/configure.go
+++ b/lib/modules/configure.go
@@ -92,6 +92,11 @@ func getBlockConfigInstance(m map[string]interface{}) (*BlockConfig, error) {
 		err := yaml.Unmarshal(yamlStr, &c)
 		b := BlockConfig(c)
 		return &b, err
+	case "cpu":
+		c := &Cpu{}
+		err := yaml.Unmarshal(yamlStr, &c)
+		b := (BlockConfig)(c)
+		return &b, err
 	case "disk":
 		c := Disk{}
 		err := yaml.Unmarshal(yamlStr, &c)

--- a/lib/modules/cpu.go
+++ b/lib/modules/cpu.go
@@ -61,7 +61,8 @@ func (c *Cpu) getCpuUsage() (float64, error) {
 
 // parseCpuLine extracts the usage from the text fields of one line of /proc/stat.
 func (c *Cpu) parseCpuLine(flds []string) (float64, error) {
-	if len(flds) < 7 {
+	// CPU lines have 10 fields since kernel version 2.6.33
+	if len(flds) < 10 {
 		return 0, errors.New("invalid line in /proc/stat")
 	}
 	var total, idle uint64

--- a/lib/modules/cpu.go
+++ b/lib/modules/cpu.go
@@ -1,0 +1,82 @@
+package modules
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"github.com/davidscholberg/go-i3barjson"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Cpu represents the configuration for the cpu block.
+type Cpu struct {
+	BlockConfigBase `yaml:",inline"`
+	Cpu             string  `yaml:"cpu"` // name of the cpu to display (from /proc/stat), empty = all
+	CritUsage       float64 `yaml:"crit_usage"`
+
+	lastIdle  uint64
+	lastTotal uint64
+}
+
+// UpdateBlock updates the status of the CPU block.
+// The block displays the CPU usage since the last update.
+func (c *Cpu) UpdateBlock(b *i3barjson.Block) {
+	b.Color = c.Color
+
+	usage, err := c.getCpuUsage()
+	if err != nil {
+		b.FullText = err.Error()
+		b.Urgent = true
+		return
+	}
+
+	b.Urgent = (c.CritUsage > 0) && (usage > c.CritUsage)
+	b.FullText = fmt.Sprintf("%s%2.0f%%", c.Label, 100*usage)
+}
+
+// getCpuUsage returns the usage of the configured CPU. It does by reading /proc/stat and
+// calculating (1 - idle_time/total_time).
+func (c *Cpu) getCpuUsage() (float64, error) {
+	f, err := os.Open("/proc/stat")
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	// find the line that corresponds to the configured CPU
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		flds := strings.Fields(s.Text())
+		if c.Cpu == "" || (len(flds) > 0 && flds[0] == c.Cpu) {
+			return c.parseCpuLine(flds[1:])
+		}
+	}
+	if s.Err() != nil {
+		return 0, s.Err()
+	}
+	return 0, fmt.Errorf("cpu %s not found", c.Cpu)
+}
+
+// parseCpuLine extracts the usage from the text fields of one line of /proc/stat.
+func (c *Cpu) parseCpuLine(flds []string) (float64, error) {
+	if len(flds) < 7 {
+		return 0, errors.New("invalid line in /proc/stat")
+	}
+	var total, idle uint64
+	for i := range flds {
+		val, err := strconv.ParseUint(flds[i], 10, 64)
+		if err != nil {
+			return 0, errors.New("invalid number")
+		}
+		total += val
+		if i == 3 {
+			idle += val
+		}
+
+	}
+	usage := 1 - (float64(idle-c.lastIdle) / float64(total-c.lastTotal))
+	c.lastTotal, c.lastIdle = total, idle
+	return usage, nil
+}


### PR DESCRIPTION
The CPU usage displays the ratio of non-idle time since the last
update. User can specify the critical usage level above which the
block is rendered as urgent.

The usage CPU times are read from /proc/stat.