### PR TITLE
Update volume display if channel is muted

### DIFF
--- a/config/goblocks-full.yml
+++ b/config/goblocks-full.yml
@@ -140,6 +140,9 @@ blocks:
       # channel defines the volume channel to monitor. If omitted, the default
       # value is "Master".
       channel: Master
+      # mute_indicator defines what to display when the channel is muted. If
+      # omitted, the default value is "muted".
+      mute_indicator: "muted"
 
     - type: uptime
       update_interval: 0.5

--- a/lib/modules/volume.go
+++ b/lib/modules/volume.go
@@ -12,6 +12,7 @@ type Volume struct {
 	BlockConfigBase `yaml:",inline"`
 	MixerDevice     string `yaml:"mixer_device"`
 	Channel         string `yaml:"channel"`
+	MuteIndicator   string `yaml:"mute_indicator"`
 }
 
 // UpdateBlock updates the volume display block.
@@ -26,22 +27,24 @@ func (c Volume) UpdateBlock(b *i3barjson.Block) {
 	if c.Channel == "" {
 		c.Channel = "Master"
 	}
+	if c.MuteIndicator == "" {
+		c.MuteIndicator = "muted"
+	}
 	amixerArgs := []string{"-D", c.MixerDevice, "get", c.Channel}
 	out, err := exec.Command(amixerCmd, amixerArgs...).Output()
 	if err != nil {
 		b.FullText = fmt.Sprintf(fullTextFmt, err.Error())
 		return
 	}
-	outStr := string(out)
-	iBegin := strings.Index(outStr, "[")
-	if iBegin == -1 {
+	outSplit := strings.Split(string(out), "[")
+	if len(outSplit) < 3 {
 		b.FullText = fmt.Sprintf(fullTextFmt, "cannot parse amixer output")
 		return
 	}
-	iEnd := strings.Index(outStr, "]")
-	if iEnd == -1 {
-		b.FullText = fmt.Sprintf(fullTextFmt, "cannot parse amixer output")
-		return
+	statusSplit := outSplit[len(outSplit)-1]
+	if statusSplit[:len(statusSplit)-2] == "on" {
+		b.FullText = fmt.Sprintf(fullTextFmt, outSplit[1][:len(outSplit[1])-2])
+	} else {
+		b.FullText = fmt.Sprintf("%s%s", c.Label, c.MuteIndicator)
 	}
-	b.FullText = fmt.Sprintf(fullTextFmt, outStr[iBegin+1:iEnd])
 }

--- a/lib/modules/volume.go
+++ b/lib/modules/volume.go
@@ -19,7 +19,7 @@ type Volume struct {
 // Currently, only the ALSA master channel volume is supported.
 func (c Volume) UpdateBlock(b *i3barjson.Block) {
 	b.Color = c.Color
-	fullTextFmt := fmt.Sprintf("%s%%s", c.Label)
+	fullTextFmt := fmt.Sprintf("%s%s", c.Label)
 	amixerCmd := "amixer"
 	if c.MixerDevice == "" {
 		c.MixerDevice = "default"
@@ -45,6 +45,6 @@ func (c Volume) UpdateBlock(b *i3barjson.Block) {
 	if statusSplit[:len(statusSplit)-2] == "on" {
 		b.FullText = fmt.Sprintf(fullTextFmt, outSplit[1][:len(outSplit[1])-2])
 	} else {
-		b.FullText = fmt.Sprintf("%s%s", c.Label, c.MuteIndicator)
+		b.FullText = fmt.Sprintf(fullTextFmt, c.MuteIndicator)
 	}
 }


### PR DESCRIPTION
Checks the amixer output to see whether the channel is [on] or [off]. Also adds a configuration option `mute_indicator` for the user to specify how they want to display the volume block when muted. Defaults to `muted`.