### PR TITLE
Skip sudo on new OpenZFS releases

### DIFF
--- a/config/goblocks-full.yml
+++ b/config/goblocks-full.yml
@@ -56,13 +56,16 @@ blocks:
       off-color: "#222222"
 
     # This block requires a passwordless sudoers entry for the user running
-    # goblocks.
+    # goblocks for OpenZFS < 0.7.0
     # E.g. ALL ALL = (root) NOPASSWD: /sbin/zpool
+    # If running OpenZFS > 0.7.0, enable skip_sudo to check zpool status
+    # without a sudeoers entry
     # Also, the zpool utility must be installed and in your $PATH.
     - type: zfs
       label: "Z: "
       zpool_name: "boot"
       update_interval: 60
+      skip_sudo: True
 
     # Only linux mdraid is supported.
     - type: raid

--- a/lib/modules/zfs.go
+++ b/lib/modules/zfs.go
@@ -11,6 +11,7 @@ import (
 type Zfs struct {
 	BlockConfigBase `yaml:",inline"`
 	PoolName        string `yaml:"zpool_name"`
+	SkipSudo        bool   `yaml:"skip_sudo"`
 }
 
 // UpdateBlock updates the ZFS block
@@ -18,8 +19,14 @@ func (c Zfs) UpdateBlock(b *i3barjson.Block) {
 	b.Color = c.Color
 	fullTextFmt := fmt.Sprintf("%s%%s", c.Label)
 
-	zpoolCmd := exec.Command("sudo", "zpool", "status", c.PoolName)
-	out, err := zpoolCmd.Output()
+	zpoolArgs := []string{"zpool", "status", c.PoolName}
+
+	if c.SkipSudo == false {
+		zpoolArgs = append([]string{"sudo"}, zpoolArgs...)
+	}
+
+	cmd, zpoolArgs := zpoolArgs[0], zpoolArgs[1:]
+	out, err := exec.Command(cmd, zpoolArgs...).Output()
 
 	if err != nil {
 		b.Urgent = true


### PR DESCRIPTION
With OpenZFS 0.7.0 released, read-only commands to interact with the zpool status no longer require root privileges. Consquently, we can now bypass needing a sudoers entry to get the pool status. To ensure backwards compatible behavior, skip_sudo needs to be set to True to remove sudo from the check. People running a new GoBlocks but old OpenZFS will not see a change in behavior as a result of this.