### PR TITLE
Add critical value capability to command module

### DIFF
--- a/lib/modules/command.go
+++ b/lib/modules/command.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	i3barjson "github.com/davidscholberg/go-i3barjson"
@@ -11,6 +12,9 @@ import (
 type Command struct {
 	BlockConfigBase `yaml:",inline"`
 	Cmd             string `yaml:"command"`
+	Append          string `yaml:"append"`
+	CritValue       string `yaml:"crit_value"`
+	CritOperator    string `yaml:"crit_operator"`
 }
 
 func (c Command) UpdateBlock(b *i3barjson.Block) {
@@ -28,5 +32,55 @@ func (c Command) UpdateBlock(b *i3barjson.Block) {
 		return
 	}
 
-	b.FullText = fmt.Sprintf(fullTextFmt, strings.TrimSpace(string(cmdOutput)))
+	// init vars as false
+	convertToIntegers := false
+	b.Urgent = false
+
+	// if we detect a < or > we have to try to convert to ints
+	if strings.Contains(c.CritOperator, "<") || strings.Contains(c.CritOperator, ">") {
+		convertToIntegers = true
+	}
+
+	// trim the script output
+	trimmedOutput := strings.TrimSpace(string(cmdOutput))
+
+	// begin int stuff
+	if convertToIntegers == true {
+		// try to convert script output to int
+		intOutput, err := strconv.Atoi(trimmedOutput)
+		if err != nil {
+			b.Urgent = true
+			msg := fmt.Sprintf("script output '%s' is not an int", trimmedOutput)
+			b.FullText = fmt.Sprintf(fullTextFmt, msg)
+			return
+		}
+
+		// try to convert crit_value to int
+		intCritValue, err := strconv.Atoi(c.CritValue)
+		if err != nil {
+			b.Urgent = true
+			msg := fmt.Sprintf("crit_value is not an int")
+			b.FullText = fmt.Sprintf(fullTextFmt, msg)
+			return
+		}
+
+		// no errors, safe to do a number comparison
+		switch c.CritOperator {
+		case ">":
+			if intOutput > intCritValue {
+				b.Urgent = true
+			}
+		case "<":
+			if intOutput < intCritValue {
+				b.Urgent = true
+			}
+		}
+	}
+
+	// safe to check equals either way
+	if c.CritOperator == "=" && c.CritValue == trimmedOutput {
+		b.Urgent = true
+	}
+
+	b.FullText = fmt.Sprintf(fullTextFmt, trimmedOutput+c.Append)
 }


### PR DESCRIPTION
I wanted more control over the command module.
Operators supported are '<', '>' and '='

An example:
```
    - type: command
      label: "Battery Example: "
      # get the battery percentage from /sys...
      command: 'cat /sys/class/power_supply/BAT1/capacity'
      # append a percentage sign to it...
      append: "%"
      # if the returned value is less than...
      crit_operator: '<'
      # 10, mark as critical
      crit_value: "10"
```